### PR TITLE
Implement missing `Send` and `Sync` traits

### DIFF
--- a/src/borrow.rs
+++ b/src/borrow.rs
@@ -10,6 +10,10 @@ pub(super) struct DormantMutRef<'a, T> {
     _marker: PhantomData<&'a mut T>,
 }
 
+// SAFETY: `DormantMutRef<'a, T>` represents a value of `&'a mut T`.
+unsafe impl<'a, T> Send for DormantMutRef<'a, T> where &'a mut T: Send {}
+unsafe impl<'a, T> Sync for DormantMutRef<'a, T> where &'a mut T: Sync {}
+
 impl<'a, T> DormantMutRef<'a, T> {
     /// Creates a dormant mutable reference and returns both the original reference and the dormant
     /// reference, so that the original reference can continue to be used.
@@ -75,6 +79,10 @@ pub(super) struct DestroyableRef<'a, T> {
     _marker: PhantomData<&'a T>,
 }
 
+// SAFETY: `DestroyableRef<'a, T>` represents a value of `&'a T`.
+unsafe impl<'a, T> Send for DestroyableRef<'a, T> where &'a T: Send {}
+unsafe impl<'a, T> Sync for DestroyableRef<'a, T> where &'a T: Sync {}
+
 impl<'a, T> DestroyableRef<'a, T> {
     /// Creates a destroyable reference from an immutable reference.
     pub fn new(val: &'a T) -> Self {
@@ -98,6 +106,10 @@ pub(super) struct DestroyableMutRef<'a, T> {
     ptr: NonNull<T>,
     _marker: PhantomData<&'a mut T>,
 }
+
+// SAFETY: `DestroyableMutRef<'a, T>` represents a value of `&'a mut T`.
+unsafe impl<'a, T> Send for DestroyableMutRef<'a, T> where &'a mut T: Send {}
+unsafe impl<'a, T> Sync for DestroyableMutRef<'a, T> where &'a mut T: Sync {}
 
 impl<'a, T> DestroyableMutRef<'a, T> {
     /// Creates a destroyable reference from an immutable reference.

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -164,6 +164,10 @@ where
     _marker: core::marker::PhantomData<(Arc<XNode<I>>, I)>,
 }
 
+// SAFETY: `XEntry<I>` represents a value of either `Arc<XNode<I>>` or `I`.
+unsafe impl<I: ItemEntry> Send for XEntry<I> where (Arc<XNode<I>>, I): Send {}
+unsafe impl<I: ItemEntry> Sync for XEntry<I> where (Arc<XNode<I>>, I): Sync {}
+
 #[derive(PartialEq, Eq, Debug)]
 #[repr(usize)]
 enum EntryType {


### PR DESCRIPTION
- `XEntry<I>` should be `Send` (`Sync`) when `(Arc<Node<I>>, I)` is.

- Implementing `Send` (`Sync`) trait for `DormantMutRef` (when `&'a mut T` is) is also fine according to:
https://github.com/rust-lang/rust/blob/0dcc1309d0e56f2121d46e20c19d332233533530/library/alloc/src/collections/btree/borrow.rs#L19-L20

So this PR adds all of these, although marking `Cursor`/`CursorMut` `Send` (`Sync`) is not quite useful.
