### PR TITLE
Add the default mark type for the public struct in this crate

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -4,7 +4,7 @@ use smallvec::SmallVec;
 
 use crate::borrow::{DestroyableMutRef, DestroyableRef, DormantMutRef};
 use crate::entry::{ItemEntry, NodeMaybeMut, XEntry};
-use crate::mark::XMark;
+use crate::mark::{NoneMark, XMark};
 use crate::node::XNode;
 use crate::xarray::{XArray, MAX_HEIGHT, SLOT_SIZE};
 
@@ -198,7 +198,7 @@ impl<'a, I: ItemEntry> CursorState<'a, I, ReadWrite> {
 /// `XArray` at the same time.
 ///
 /// The typical way to obtain a `Cursor` instance is to call [`XArray::cursor`].
-pub struct Cursor<'a, I, M>
+pub struct Cursor<'a, I, M = NoneMark>
 where
     I: ItemEntry,
     M: Into<XMark>,
@@ -409,7 +409,7 @@ impl<'a, I: ItemEntry> NodeMutRef<'a, I> {
 /// the `XArray`. However, just before performing the modification, `CursorMut` will create
 /// exclusive copies by cloning shared items, which guarantees the isolation of data stored in
 /// different `XArray`s.
-pub struct CursorMut<'a, I, M>
+pub struct CursorMut<'a, I, M = NoneMark>
 where
     I: ItemEntry,
     M: Into<XMark>,

--- a/src/range.rs
+++ b/src/range.rs
@@ -1,6 +1,6 @@
 use crate::cursor::Cursor;
 use crate::entry::ItemEntry;
-use crate::mark::XMark;
+use crate::mark::{NoneMark, XMark};
 
 /// An iterator over a range of entries in an [`XArray`].
 ///
@@ -8,7 +8,7 @@ use crate::mark::XMark;
 ///
 /// [`XArray`]: crate::XArray
 /// [`XArray::range`]: crate::XArray::range
-pub struct Range<'a, I, M>
+pub struct Range<'a, I, M = NoneMark>
 where
     I: ItemEntry,
     M: Into<XMark>,


### PR DESCRIPTION
Add the default mark type for `Cursor`, `CursorMut` and `Range`. This allows users to use these public structs without declaring additional generic parameter if they don't need the mark functionality.